### PR TITLE
Fix an issue with undefined `link` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-rss-feed",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Gatsby source plugin for rss feed",
   "main": "gatsby-node.js",
   "scripts": {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -70,7 +70,7 @@ exports.sourceNodes = async ({
   const { items, ...other } = feed
 
   items.forEach(item => {
-    const nodeId = createNodeId(item.link)
+    const nodeId = createNodeId(item.guid)
     const normalizedItem = normalize(item)
     renameSymbolKeys(normalizedItem)
     createNode({


### PR DESCRIPTION
For some reason, at least with the rss feed that I'm testing, the `link` property is not available so the plugin fails when building.
I updated the use of `link` as node id to use `guid` instead.