### PR TITLE
Fix an issue with undefined `guid` property

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -70,7 +70,7 @@ exports.sourceNodes = async ({
   const { items, ...other } = feed
 
   items.forEach(item => {
-    const nodeId = createNodeId(item.guid)
+    const nodeId = createNodeId(item.guid || item.link)
     const normalizedItem = normalize(item)
     renameSymbolKeys(normalizedItem)
     createNode({


### PR DESCRIPTION
If guid property is blank, build fails. I use guid  as nodeId if guid is blank